### PR TITLE
Dont break on generic middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
-          node_js:
-            - "0.11"
+node_js:
+  - "0.11"
+  - "0.12"

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -22,6 +22,9 @@ const mapExpress4Routes = function (app) {
     .filter(function (entry) {
       return ignoredRoutes.indexOf(entry.name) === -1
     })
+    .filter(function (entry) {
+      return Boolean(entry.route)
+    })
     .map(function (entry) {
       var route = entry.route
       return Object.keys(route.methods)

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "lodash-node": "~2.4.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.7.1",
-    "mocha": "^1.20.1",
+    "coffee-script": "^1.9.2",
+    "lodash-node": "^2.4.1",
+    "mocha": "^2.2.4",
     "rf-release": "^0.1.2",
-    "should": "^4.0.4"
+    "should": "^6.0.1"
   }
 }

--- a/test/unit/middleware.spec.coffee
+++ b/test/unit/middleware.spec.coffee
@@ -35,6 +35,11 @@ class Express4RouterFixture
     @app._router.stack.push {name, route}
     this
 
+  withUse: (name) ->
+    route = undefined
+    @app._router.stack.push {name}
+    this
+
   build: -> @app
 
 
@@ -154,6 +159,17 @@ describe 'express-ls-routes', ->
         .build()
       expected = [
         'GET    /aPath'
+      ]
+      lsRoutes(app) req, null, ->
+        req.routes.should.eql expected
+    
+    it 'does not break when using other generic middlewares with .use()', ->
+      app = router
+        .withUse('logger')
+        .withRoute('get', '/myPath')
+        .build()
+      expected = [
+        'GET    /myPath'
       ]
       lsRoutes(app) req, null, ->
         req.routes.should.eql expected


### PR DESCRIPTION
When using `morgan`, lsRoutes() did not work and broke on the logger middleware.
This is because middleware mounted with `.use()` do not have a `route` property.

This PR adds a test for it and fixes it.
